### PR TITLE
update to latest instructions on cra/typescript-prettier page

### DIFF
--- a/pages/cra/typescript-prettier.tsx
+++ b/pages/cra/typescript-prettier.tsx
@@ -9,32 +9,20 @@ export default function PageCreateReactAppTypeScriptPrettier() {
       <PageHeader>TypeScript &amp; Prettier</PageHeader>
       <Section title="Dependencies">
         <CodeBlock isScrollable>
-          {`npm install --save-dev eslint-config-react-app @typescript-eslint/eslint-plugin@^4.0.0 @typescript-eslint/parser@^4.0.0 babel-eslint@^10.0.0 eslint@^7.5.0 eslint-plugin-flowtype@^5.2.0 eslint-plugin-import@^2.22.0 eslint-plugin-jsx-a11y@^6.3.1 eslint-plugin-react@^7.20.3 eslint-plugin-react-hooks@^4.0.8 prettier@^2.1.2 eslint-config-prettier@^6.12.0 eslint-plugin-prettier@^3.1.4`}
+          {`npm install --save-dev prettier eslint-config-prettier eslint-plugin-prettier`}
         </CodeBlock>
       </Section>
       <Section title=".eslintrc.js">
         <CodeBlock isScrollable>
           {`module.exports = {
-  parser: "@typescript-eslint/parser",
   extends: [
-    "react-app", // Uses the recommended rules Create React App
-    "plugin:@typescript-eslint/recommended", // Uses the recommended rules from @typescript-eslint/eslint-plugin
-    "prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
-    "plugin:prettier/recommended" // Should be last in the list. Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    "react-app", // create-react-app base settings
+    "eslint:recommended", // recommended eslint rules
+    "plugin:@typescript-eslint/recommended", // recommended typescript rules
+    "prettier/@typescript-eslint", // disables typescript formatting rules
+    "plugin:prettier/recommended", // disables eslint formatting rules and uses prettier (must be last)
   ],
-  parserOptions: {
-    ecmaFeatures: {
-      jsx: true // Allows for the parsing of JSX
-    },
-    ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
-    sourceType: "module" // Allows for the use of imports
-  },
   rules: {},
-  settings: {
-    react: {
-      version: "detect" // Tells eslint-plugin-react to automatically detect the version of React to use
-    }
-  }
 };
 
 `}


### PR DESCRIPTION
This PR updates the instructions for the `cra/typescript-prettier` page based on my research and as I would recommend it today. This addresses issues #8 and #9.

Changes:
- Don't ask the user to install dependencies that are [already included](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/package.json) as part of `react-scripts`. It isn't needed and allows that project to determine the required / compatible versions of each. For reference see [the `eslint-config-react-app` documentation](https://www.npmjs.com/package/eslint-config-react-app#usage-in-create-react-app-projects) which says:
    > You don’t need to install it separately in Create React App projects.
- Do ask the user to install `prettier`, `eslint-config-prettier`, and `eslint-plugin-prettier`
- Don't specify any version constraints on these since they are not currently needed
- Removed most settings from our recommended `.eslintrc.js` since they are [already included in the `react-app` config](https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/index.js) which we extend. When that package is upgraded we will get it's latest settings.
- In `.eslintrc.js` I also added `eslint:recommended` to the `extends` list. This adds the recommended eslint rules for all projects (not just typescript projects) and is [recommended by typescript here](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin/#recommended-configs)


Also not sure if it is worth adding to our documentation but by default the `start` and `build` scripts will NOT use our `.eslintrc.js` file. This can be enabled by setting the [experimental environment variable](https://create-react-app.dev/docs/setting-up-your-editor/#experimental-extending-the-eslint-config) `EXTEND_ESLINT=true`. IMO the default is the right option since otherwise a lint error would crash a running app. Better I think to have a separate lint script that is run manually or in CI before building. VSCode will use out config and show lint errors for any open file.