### PR TITLE
Packaged merged into prettier

### DIFF
--- a/pages/cra/typescript-prettier.tsx
+++ b/pages/cra/typescript-prettier.tsx
@@ -19,7 +19,6 @@ export default function PageCreateReactAppTypeScriptPrettier() {
     "react-app", // Create React App base settings
     "eslint:recommended", // recommended ESLint rules
     "plugin:@typescript-eslint/recommended", // recommended rules from @typescript-eslint/eslint-plugin
-    "prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with Prettier.
     "plugin:prettier/recommended", // Enables eslint-plugin-prettier and eslint-config-prettier. This will display Prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
   rules: {},


### PR DESCRIPTION
Got the following error when following the website:

Error: "prettier/@typescript-eslint" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21

Given it has been merged upstream, I removed the recommendation.